### PR TITLE
Adding support for durations

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "raf-stub",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Test stubbing for requestAnimationFrame",
   "main": "lib/index.js",
   "jsnext:main": "src/index.js",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
   "description": "Test stubbing for requestAnimationFrame",
   "main": "lib/index.js",
   "jsnext:main": "src/index.js",
-  "dependencies": {},
+  "dependencies": {
+    "performance-now": "^0.2.0"
+  },
   "devDependencies": {
     "babel-cli": "^6.9.0",
     "babel-core": "^6.9.0",

--- a/readme.md
+++ b/readme.md
@@ -273,8 +273,11 @@ api.step();
 This function is used to set a `requestAnimationFrame` and `cancelAnimationFrame` on a root (eg `window`).
 
 - `roots (?Array)` => an optional array of roots to be stubbed (eg [`window`, `global`]). If no root is provided then the function will automatically figure out whether to use `window` or `global`
-- `startTime (Int)` =>
-- `frameDuration (Number)` =?
+- `options (?Object)` => optional additional values
+
+`options`
+- `startTime (Int)` => see `createStub()`
+- `frameDuration (Number)` => see `createStub()`
 
 
 #### Basic usage

--- a/readme.md
+++ b/readme.md
@@ -10,6 +10,7 @@ Accurate and predictable testing of `requestAnimationFrame` and `cancelAnimation
 - Continue to call `requestionAnimationFrame` until there are no frames left. This lets you fast forward to the end of animations.
 - Clear out all animation frames without calling them
 - Control animations that are orchestrated by third party libraries such as [react-motion](https://github.com/chenglou/react-motion)
+- Control time values passed to your `requestAnimationFrame` callbacks
 
 This is **not** designed to be a polyfill and is only intended for testing code.
 
@@ -99,17 +100,20 @@ npm i --save-dev raf-stub
 
 ## stub
 Created by `createStub()`
-
 An isolated mock that contains it's own state. Each `stub` is independent and have it's own state.
+
+**Note** changing the time values (`startTime`, `frameDuration` and `duration`) does not actually impact how long your test takes to execute, nor does it attach itself to the system clock. It is simply a way for you to have control over the first argument (`currentTime`) to `requestAnimationFrame` callbacks.
 
 ### `createStub(?frameDuration = 1000 / 60, ?startTime = performance.now()) => Stub`
 
 **Basic usage**
+
 ```js
 const stub = createStub();
 ```
 
 **Advanced usage**
+
 ```js
 const frameDuration = 1000 / 60 * 2; // an extra slow frame
 const startTime = performance.now() + 1000;
@@ -146,8 +150,8 @@ stub.remove(callback);
 ### `.step(?steps=1, ?duration = frameDuration)`
 Executes all callbacks in the current frame and optionally additional frames.
 
-- *steps (Int)* => the amount of animation frames you would like to release. This is useful when you have nested calls.
-- *duration (Number)* => the default `duration` value is provided by the `frameDuration` argument to `createStub(frameDuration)`. However, you can override it for a specific `.step()` call using the `duration` argument.
+- `steps (Int)` => the amount of animation frames you would like to release. This is useful when you have nested calls.
+- `duration (Number)` => the amount of time the frame takes to execute. The default `duration` value is provided by the `frameDuration` argument to `createStub(frameDuration)`. However, you can override it for a specific `.step()` call using the `duration` argument.
 
 **Simple example**
 
@@ -209,11 +213,12 @@ stub.step(1, longFrameDuration);
 ### `.flush(?duration = frameDuration)`
 Executes all `requestAnimationFrame` callbacks, including nested calls. It will keep executing frames until there are no frames left. An easy way to to think of this function is "`step()` until there are no more steps left"
 
-- *duration (Number)* => the default `duration` value is provided by the `frameDuration` argument to `createStub(frameDuration)`. However, you can override it for a specific `.flush()` call using the `duration` argument. The `duration` will be applied to all frames in the flush.
+- `duration (Number)` => the duration for each frame in the flush - each frame gets the same value. If you want different frames to get different values then use `.step()`. The default `duration` value is provided by the `frameDuration` argument to `createStub(frameDuration)`. However, you can override it for a specific `.flush()` call using the `duration` argument.
 
 **Warning** if your code just calls `requestAnimationFrame` in an infinite loop then this will never end. Consider using `.step()` for this use case
 
 **Simple example**
+
 ```js
 // this example will use the 'replaceRaf' syntax as it is a little clearer
 
@@ -232,7 +237,17 @@ api.flush();
 ```
 
 **Time manipulated example**
-[TODO]
+
+```js
+const startTime = performance.now();
+const stub = createStub(100, startTime);
+const callback = currentTime => console.log(`call time: ${currentTime - startTime}`);
+
+stub.add(callback);
+stub.flush(200);
+
+// console.log => 'call time: 200'
+```
 
 ### `.reset()`
 
@@ -253,9 +268,13 @@ api.step();
 
 ## replaceRaf
 
-### `replaceRaf([roots], {frameDuration = 1000/ 60, startTime = performance.now()})`
+### `replaceRaf(?[roots], ?{frameDuration = 1000/ 60, startTime = performance.now()})`
 
-This function is used to set a `requestAnimationFrame` and `cancelAnimationFrame` on a root (eg `window`). You can manually pass in a `root`, or `roots`. If you do not pass in a root it will automatically figure out whether to use `window` or `global`.
+This function is used to set a `requestAnimationFrame` and `cancelAnimationFrame` on a root (eg `window`).
+
+- `roots (?Array)` => an optional array of roots to be stubbed (eg [`window`, `global`]). If no root is provided then the function will automatically figure out whether to use `window` or `global`
+- `startTime (Int)` =>
+- `frameDuration (Number)` =?
 
 
 #### Basic usage
@@ -332,7 +351,7 @@ var replaceRaf = require('raf-stub').replaceRaf;
 
 ## Recipes
 
-## Controlling the `frameDuration` and `startTime`
+## `frameDuration` and `startTime`
 
 The first argument to a `requestAnimationFrame` callback is a [DOMHighResTimeStamp](https://developer.mozilla.org/en-US/docs/Web/API/DOMHighResTimeStamp)
 
@@ -365,7 +384,7 @@ stub.step();
 // console.log => 'a slow frame occured'
 ```
 
-**How to control the `frameDuration` and `startTime`:**
+**Controlling the `frameDuration` and `startTime`:**
 
 ```js
 const callback = currentTime => console.log(`time taken: ${currentTime - startTime}`);
@@ -379,7 +398,7 @@ stub.step();
 // console.log => 'time taken: 100'
 
 stub.add(callback);
-// this will overwrite the frameDuration to '200' for this call
+// this will overwrite the duration of the frame to '200' for this call
 stub.step(1, 200);
 // console.log => 'time taken: 200'
 
@@ -744,5 +763,100 @@ describe('app', () => {
 ```
 
 We got around this issue by flushing the clock. We did this by calling `clock.tick(some big number)`. This suffers from the problem that existed a previous example: you cannot be sure that you have actually emptied the queue. You might have noticed a strange `console.log` in the `afterEach` function. This is because when you emptied the `setTimeout` queue with `clock.tick` all of the callbacks executed. In some cases it might lead to unintended consequences. `stub.reset()` allows us to empty a queue **without** needing to execute any of the callbacks.
+
+### Case 4: controlling the first argument to `requestAnimationFrame` callbacks
+
+Lets say you have setup that looks like this:
+
+```js
+const idealFrameDuration = 1000 / 60;
+
+const startAnimation = startTime => {
+    let previousTime = startTime;
+
+    const loop = currentTime => {
+        if(!currentTime) {
+            throw new Error('could not get the current time');
+        }
+
+        if(currentTime - previousTime > idealFrameDuration) {
+            console.log('a slow frame occurred');
+        } else {
+            console.log('a normal frame occurred');
+        }
+
+        previousTime = currentTime;
+        requestAnimationFrame(loop);
+    }
+
+    requestAnimationFrame(loop);
+
+
+};
+
+startAnimation(new Date().getTime());
+```
+
+How could we test the behaviour of the `loop` function? Let's try with `setTimeout`
+
+```js
+describe('startAnimation', () => {
+    let clock;
+
+    beforeEach(() => {
+        clock = sinon.useFakeTimers();
+        sinon.stub(window, 'requestAnimationFrame', setTimeout);
+        sinon.stub(window, 'cancelAnimationFrame', clearTimeout);
+    });
+
+    afterEach(() => {
+        clock.restore();
+        window.requestAnimationFrame.restore();
+        window.cancelAnimationFrame.restore();
+    });
+
+    it('should pass the updated time to loop', () => {
+        const startTime = performance.now();
+        startAnimation(startTime);
+
+        clock.tick();
+
+        // Error => 'could not get the current time'
+    });
+});
+```
+
+What happened here? By default `setTimeout` does not pass any argument as the first parameter to callbacks. Getting this to work is hard because we would need to both use `setTimeout` as a replacement for `requestAnimationFrame` as well as changing it's behaviour to pass a controlled value as the first argument.
+
+How can `raf-stub` help us?
+
+```js
+import {replaceRaf} from 'raf-stub';
+const startTime = performance.now();
+const idealFrameDuration = 1000 / 60;
+
+replaceRaf([], {startTime});
+
+describe('startAnimation', () => {
+
+    afterEach(() => {
+        requestAnimationFrame.reset();
+    });
+
+    it('should pass the updated time to loop', () => {
+
+        const slowFrameDuration = idealFrameDuration * 2;
+        startAnimation(startTime);
+
+        requestAnimationFrame.step(1, idealFrameDuration);
+        // console.log => 'a normal frame occurred'
+
+
+        requestAnimationFrame.step(1, slowFrameDuration);
+        // console.log => 'a slow frame occurred'
+    });
+});
+```
+
 
 

--- a/readme.md
+++ b/readme.md
@@ -253,7 +253,7 @@ api.step();
 
 ## replaceRaf
 
-### `replaceRaf(?roots)`
+### `replaceRaf([roots], {frameDuration = 1000/ 60, startTime = performance.now()})`
 
 This function is used to set a `requestAnimationFrame` and `cancelAnimationFrame` on a root (eg `window`). You can manually pass in a `root`, or `roots`. If you do not pass in a root it will automatically figure out whether to use `window` or `global`.
 
@@ -263,16 +263,19 @@ This function is used to set a `requestAnimationFrame` and `cancelAnimationFrame
 import {replaceRaf} from 'raf-stub';
 
 const root = {}; // could be window, global etc.
-replaceRaf(root);
+replaceRaf([root]);
 
 // can let multiple roots share the one stub
 // useful for when you testing environment uses `global`
 // but some libraries may use `window`
 
-replaceRaf(window, global);
+replaceRaf([window, global]);
 
 // if called with no arguments it will use 'window' in the browser and 'global' in node
 replaceRaf();
+
+// you can override the frameDuration and startTime for the stub
+replaceRaf([window], {frameDuration: 200, startTime: new Date().getTime() + 1000 })
 ```
 
 After calling `replaceRaf` a root it's `requestAnimationFrame` and `cancelAnimationFrame` functions have been set and given new capabilities.

--- a/src/index.js
+++ b/src/index.js
@@ -67,6 +67,13 @@ export default function createStub(frameDuration = defaultDuration, startTime = 
 
 // all calls to replaceRaf get the same stub;
 export function replaceRaf(roots = [], {duration = defaultDuration, startTime = now()} = {}) {
+    // 0.3.x api support
+    if (arguments.length && !Array.isArray(roots)) {
+        console.info('hi');
+        console.warn('replaceRaf(roots) has been depreciated. Please now use replaceRaf([roots], options). See here for more details: https://github.com/alexreardon/raf-stub/releases');
+        roots = Array.from(arguments);
+    }
+
     if (!roots.length) {
         roots.push(typeof window !== 'undefined' ? window : global);
     }

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,11 @@
-export default function createStub() {
+const now = require('performance-now');
+const defaultDuration = 1000 / 60;
+
+export default function createStub(frameDuration = defaultDuration) {
     const frames = [];
     let frameId = 0;
+    const startTime = now();
+    let currentTime = startTime;
 
     function add(cb) {
         const id = ++frameId;
@@ -30,24 +35,27 @@ export default function createStub() {
         frames.splice(index, 1);
     }
 
-    function flush() {
+    function flush(duration = frameDuration) {
         while (frames.length) {
-            step();
+            step(1, duration);
         }
     }
 
     function reset() {
         frames.length = 0;
+        currentTime = startTime;
     }
 
-    function step(steps = 1) {
+    function step(steps = 1, duration = frameDuration) {
         if (steps === 0) {
             return;
         }
 
+        currentTime = currentTime + duration;
+
         const shallow = frames.slice(0);
         shallow.forEach(frame => {
-            frame.callback();
+            frame.callback(currentTime);
         });
 
         return step(steps - 1);
@@ -64,6 +72,7 @@ export function replaceRaf(...roots) {
         roots.push(typeof window !== 'undefined' ? window : global);
     }
 
+    // TODO
     const stub = createStub();
 
     roots.forEach(root => {

--- a/src/index.js
+++ b/src/index.js
@@ -1,17 +1,16 @@
 const now = require('performance-now');
 const defaultDuration = 1000 / 60;
 
-export default function createStub(frameDuration = defaultDuration) {
+export default function createStub(frameDuration = defaultDuration, startTime = now()) {
     const frames = [];
     let frameId = 0;
-    const startTime = now();
     let currentTime = startTime;
 
     function add(cb) {
         const id = ++frameId;
 
-        const callback = function () {
-            cb();
+        const callback = function (time) {
+            cb(time);
             // remove callback from frames after calling it
             remove(id);
         };
@@ -67,13 +66,12 @@ export default function createStub(frameDuration = defaultDuration) {
 }
 
 // all calls to replaceRaf get the same stub;
-export function replaceRaf(...roots) {
+export function replaceRaf(roots = [], {duration = defaultDuration, startTime = now()} = {}) {
     if (!roots.length) {
         roots.push(typeof window !== 'undefined' ? window : global);
     }
 
-    // TODO
-    const stub = createStub();
+    const stub = createStub(duration, startTime);
 
     roots.forEach(root => {
         root.requestAnimationFrame = stub.add;

--- a/src/index.js
+++ b/src/index.js
@@ -57,7 +57,7 @@ export default function createStub(frameDuration = defaultDuration, startTime = 
             frame.callback(currentTime);
         });
 
-        return step(steps - 1);
+        return step(steps - 1, duration);
     }
 
     return {
@@ -69,7 +69,6 @@ export default function createStub(frameDuration = defaultDuration, startTime = 
 export function replaceRaf(roots = [], {duration = defaultDuration, startTime = now()} = {}) {
     // 0.3.x api support
     if (arguments.length && !Array.isArray(roots)) {
-        console.info('hi');
         console.warn('replaceRaf(roots) has been depreciated. Please now use replaceRaf([roots], options). See here for more details: https://github.com/alexreardon/raf-stub/releases');
         roots = Array.from(arguments);
     }

--- a/test/index.js
+++ b/test/index.js
@@ -220,6 +220,15 @@ describe('instance', () => {
         });
 
         describe('duration', () => {
+            it('should use the default time when no duration is provided', () => {
+                const callback = sinon.stub();
+
+                api.add(callback);
+                api.step();
+
+                expect(callback.calledWith(startTime + frameDuration)).to.be.true;
+            });
+
             it('should pass the current time + duration to callbacks', () => {
                 const callback = sinon.stub();
                 const duration = 10;
@@ -230,13 +239,18 @@ describe('instance', () => {
                 expect(callback.calledWith(startTime + duration)).to.be.true;
             });
 
-            it('should use the default time when no duration is provided', () => {
-                const callback = sinon.stub();
+            it('should also pass the duration to mutli-step calls', () => {
+                const duration = 10;
+                const child = sinon.stub();
+                const parent = sinon.spy(function () {
+                    api.add(child);
+                });
 
-                api.add(callback);
-                api.step();
+                api.add(parent);
+                api.step(2, duration);
 
-                expect(callback.calledWith(startTime + frameDuration)).to.be.true;
+                expect(parent.calledWith(startTime + duration)).to.be.true;
+                expect(child.calledWith(startTime + duration * 2)).to.be.true;
             });
 
             it('should increase the time taken by the duration in each step', () => {

--- a/test/index.js
+++ b/test/index.js
@@ -32,7 +32,7 @@ describe('createStub', () => {
 
         expect(callback.calledWith(startTime + customDuration)).to.be.true;
     });
-    
+
     it('should allow you to pass in a custom start time', () => {
         const customDuration = 1000;
         const startTime = now() + 1000;
@@ -509,6 +509,40 @@ describe('replaceRaf', () => {
             root.requestAnimationFrame.flush();
 
             expect(callback.calledWith(customStartTime + defaultDuration)).to.be.true;
+        });
+    });
+
+    describe('0.3.x support', () => {
+        beforeEach(() => {
+            sinon.stub(console, 'warn');
+        });
+
+        afterEach(() => {
+            console.warn.restore();
+        });
+
+        it('should support a single root as an argument', () => {
+           const root = {};
+
+            replaceRaf(root);
+
+            expect(root.requestAnimationFrame).to.be.a.function;
+        });
+
+        it('should support passing in multiple roots separated by commas', () => {
+            const root1 = {};
+            const root2 = {};
+
+            replaceRaf(root1, root2);
+
+            expect(root1.requestAnimationFrame).to.equal(root2.requestAnimationFrame);
+        });
+        it('should log a deprecation message', () => {
+            const root = {};
+
+            replaceRaf(root);
+
+            expect(console.warn.called).to.be.true;
         });
     });
 

--- a/test/index.js
+++ b/test/index.js
@@ -1,11 +1,14 @@
-import factory, {replaceRaf} from '../src/index';
+import createStub, {replaceRaf} from '../src/index';
 import sinon from 'sinon';
 import {expect} from 'chai';
+import now from 'performance-now';
+
+const defaultDuration = 1000 / 60;
 
 describe('createStub', () => {
     it('should allow for different stub namespaces', () => {
-        const api1 = factory();
-        const api2 = factory();
+        const api1 = createStub();
+        const api2 = createStub();
         const callback1 = sinon.stub();
         const callback2 = sinon.stub();
 
@@ -17,13 +20,39 @@ describe('createStub', () => {
         expect(callback1.called).to.be.true;
         expect(callback2.called).to.be.false;
     });
+
+    it('should allow you to pass in a custom frame duration', () => {
+        const customDuration = 1000;
+        const startTime = now();
+        const callback = sinon.stub();
+        const api = createStub(customDuration, startTime);
+
+        api.add(callback);
+        api.flush();
+
+        expect(callback.calledWith(startTime + customDuration)).to.be.true;
+    });
+    
+    it('should allow you to pass in a custom start time', () => {
+        const customDuration = 1000;
+        const startTime = now() + 1000;
+        const callback = sinon.stub();
+        const api = createStub(customDuration, startTime);
+
+        api.add(callback);
+        api.flush();
+
+        expect(callback.calledWith(startTime + customDuration)).to.be.true;
+    });
 });
 
 describe('instance', () => {
+    const startTime = now();
+    const frameDuration = 10;
     let api;
 
     beforeEach(() => {
-        api = factory();
+        api = createStub(frameDuration, startTime);
     });
 
     afterEach(() => {
@@ -189,6 +218,43 @@ describe('instance', () => {
                 expect(callback.firstCall.returnValue).to.equal(bar.a);
             });
         });
+
+        describe('duration', () => {
+            it('should pass the current time + duration to callbacks', () => {
+                const callback = sinon.stub();
+                const duration = 10;
+
+                api.add(callback);
+                api.step(1, duration);
+
+                expect(callback.calledWith(startTime + duration)).to.be.true;
+            });
+
+            it('should use the default time when no duration is provided', () => {
+                const callback = sinon.stub();
+
+                api.add(callback);
+                api.step();
+
+                expect(callback.calledWith(startTime + frameDuration)).to.be.true;
+            });
+
+            it('should increase the time taken by the duration in each step', () => {
+                const child = sinon.stub();
+                const parent = sinon.spy(function () {
+                    api.add(child);
+                });
+                const parentDuration = 10;
+                const childDuration = 100000;
+
+                api.add(parent);
+                api.step(1, parentDuration);
+                api.step(1, childDuration);
+
+                expect(parent.calledWith(startTime + parentDuration)).to.be.true;
+                expect(child.calledWith(startTime + parentDuration + childDuration)).to.be.true;
+            });
+        });
     });
 
     describe('flush', () => {
@@ -215,6 +281,33 @@ describe('instance', () => {
 
             expect(parent.called).to.be.true;
             expect(child.called).to.be.true;
+        });
+
+        it('should execute all nested callbacks with the stubs frame duration', () => {
+            const parent = sinon.spy(function () {
+                api.add(child);
+            });
+            const child = sinon.stub();
+
+            api.add(parent);
+            api.flush();
+
+            expect(parent.calledWith(startTime + frameDuration)).to.be.true;
+            expect(child.calledWith(startTime + 2 * frameDuration)).to.be.true;
+        });
+
+        it('should allow you to flush callbacks with a provided frame duration', () => {
+            const parent = sinon.spy(function () {
+                api.add(child);
+            });
+            const child = sinon.stub();
+            const customDuration = frameDuration * 10;
+
+            api.add(parent);
+            api.flush(customDuration);
+
+            expect(parent.calledWith(startTime + customDuration)).to.be.true;
+            expect(child.calledWith(startTime + 2 * customDuration)).to.be.true;
         });
 
     });
@@ -244,6 +337,22 @@ describe('instance', () => {
             expect(parent.called).to.be.false;
             expect(child.called).to.be.false;
         });
+
+        it('should reset the current time back to the start time', () => {
+            const callback1 = sinon.stub();
+            const callback2 = sinon.stub();
+
+            api.add(callback1);
+            api.flush();
+            api.reset();
+
+            // if not reset then duration would be startTime + 2 * duration
+            api.add(callback2);
+            api.flush();
+
+            expect(callback1.calledWith(startTime + frameDuration)).to.be.true;
+            expect(callback2.calledWith(startTime + frameDuration)).to.be.true;
+        });
     });
 });
 
@@ -252,17 +361,18 @@ describe('replaceRaf', () => {
         const root = {};
         const callback = sinon.stub();
 
-        replaceRaf(root);
+        replaceRaf([root]);
         root.requestAnimationFrame(callback);
         root.requestAnimationFrame.flush();
 
         expect(callback.called).to.be.true;
     });
+
     it('should replace root.cancelAnimationFrame with "remove"', () => {
         const root = {};
         const callback = sinon.stub();
 
-        replaceRaf(root);
+        replaceRaf([root]);
         const id = root.requestAnimationFrame(callback);
         root.cancelAnimationFrame(id);
         root.requestAnimationFrame.flush();
@@ -274,32 +384,54 @@ describe('replaceRaf', () => {
         const root = {};
         const callback = sinon.stub();
 
-        replaceRaf(root);
+        replaceRaf([root]);
         root.requestAnimationFrame(callback);
         root.requestAnimationFrame.step();
 
         expect(callback.called).to.be.true;
     });
+
     it('should add "flush" to the root.requestAnimationFrame', () => {
         const root = {};
         const callback = sinon.stub();
 
-        replaceRaf(root);
+        replaceRaf([root]);
         root.requestAnimationFrame(callback);
         root.requestAnimationFrame.flush();
 
         expect(callback.called).to.be.true;
     });
+
     it('should add "reset" to the root.requestAnimationFrame', () => {
         const root = {};
         const callback = sinon.stub();
 
-        replaceRaf(root);
+        replaceRaf([root]);
+        replaceRaf([root]);
         root.requestAnimationFrame(callback);
         root.requestAnimationFrame.reset();
         root.requestAnimationFrame.flush();
 
         expect(callback.called).to.be.false;
+    });
+
+    it('should share stubs between roots', () => {
+        const root1 = {};
+        const root2 = {};
+
+        replaceRaf([root1, root2]);
+
+        expect(root1.requestAnimationFrame).to.equal(root2.requestAnimationFrame);
+    });
+
+    it('should not share stubs between different calls', () => {
+        const root1 = {};
+        const root2 = {};
+
+        replaceRaf([root1]);
+        replaceRaf([root2]);
+
+        expect(root1.requestAnimationFrame).to.not.equal(root2.requestAnimationFrame);
     });
 
     describe('no root provided', () => {
@@ -332,4 +464,52 @@ describe('replaceRaf', () => {
             expect(global.requestAnimationFrame).to.be.a.function;
         });
     });
+
+    describe('time', () => {
+        const startTime = now();
+
+        it('should use the default duration if none is provided', () => {
+            const root = {};
+            const callback = sinon.stub();
+
+            replaceRaf([root], {startTime});
+
+            root.requestAnimationFrame(callback);
+            root.requestAnimationFrame.flush();
+
+            expect(callback.calledWith(startTime + defaultDuration)).to.be.true;
+        });
+
+        it('should use the custom duration if none is provided', () => {
+            const root = {};
+            const callback = sinon.stub();
+            const customDuration = defaultDuration * 1000;
+
+            replaceRaf([root], {
+                startTime,
+                duration: customDuration
+            });
+
+            root.requestAnimationFrame(callback);
+            root.requestAnimationFrame.flush();
+
+            expect(callback.calledWith(startTime + customDuration)).to.be.true;
+        });
+
+        it('should use the custom start time if none is provided', () => {
+            const root = {};
+            const callback = sinon.stub();
+            const customStartTime = startTime + 1000;
+
+            replaceRaf([root], {
+                startTime: customStartTime
+            });
+
+            root.requestAnimationFrame(callback);
+            root.requestAnimationFrame.flush();
+
+            expect(callback.calledWith(customStartTime + defaultDuration)).to.be.true;
+        });
+    });
+
 });


### PR DESCRIPTION
Resolves #1 . 

Not a finished solution yet. Still need to:
- [x] write tests for all use cases
- [x] work out a nice api for the `replaceRaf` function. Ideally one that is backwards compatible. 
- [x] update `readme.md`
- [x] make old `replaceRaf()` api work but log a depreciation message

/cc @QbeRoot
