### PR TITLE
moving to fixed versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,23 +1,23 @@
 {
   "name": "raf-stub",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Accurate and predictable testing of requestAnimationFrame and cancelAnimationFrame",
   "main": "lib/index.js",
   "jsnext:main": "src/index.js",
   "dependencies": {
-    "performance-now": "^0.2.0"
+    "performance-now": "0.2.0"
   },
   "devDependencies": {
-    "babel-cli": "^6.9.0",
-    "babel-core": "^6.9.0",
-    "babel-eslint": "^7.0.0",
-    "babel-preset-es2015": "^6.9.0",
-    "chai": "^3.5.0",
-    "codecov": "^1.0.1",
-    "eslint": "^3.0.0",
-    "isparta": "^4.0.0",
-    "mocha": "^3.0.0",
-    "sinon": "^1.17.4"
+    "babel-cli": "6.16.0",
+    "babel-core": "6.17.0",
+    "babel-eslint": "7.0.0",
+    "babel-preset-es2015": "6.16.0",
+    "chai": "3.5.0",
+    "codecov": "1.0.1",
+    "eslint": "3.7.1",
+    "isparta": "4.0.0",
+    "mocha": "3.1.0",
+    "sinon": "1.17.6"
   },
   "scripts": {
     "test": "npm run lint && ./node_modules/.bin/mocha test --compilers js:babel-core/register",


### PR DESCRIPTION
Moving to fixed versions in `package.json` to avoid fuzzy dependencies breaking in minor or patch versions. Also bumping versions. 
