### PR TITLE
Make stub type-safe

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "eslint": "4.19.1",
     "eslint-plugin-flowtype": "2.46.1",
     "eslint-plugin-jest": "^21.15.0",
-    "flow-bin": "0.68.0",
+    "flow-bin": "0.100.0",
     "flow-copy-source": "1.3.0",
     "jest": "^22.4.3",
     "rimraf": "2.6.2"

--- a/src/index.js
+++ b/src/index.js
@@ -3,11 +3,17 @@ import now from 'performance-now';
 import { defaultFrameDuration } from './constants';
 
 type Stub = {|
-  add: (cb: Function) => number,
+  add: {
+    [[call]]: (cb: () => void) => number,
+    remove: (id: number) => void,
+    flush: (duration?: number) => void,
+    reset: () => void,
+    step: (steps?: number, duration?: number) => void
+  },
   remove: (id: number) => void,
   flush: (duration?: number) => void,
   reset: () => void,
-  step: (steps?: number, duration?: number) => void
+  step: (steps?: number, duration?: number) => void,
 |};
 
 type Frame = {|
@@ -76,6 +82,11 @@ export default function createStub (frameDuration: number = defaultFrameDuration
     return step(steps - 1, duration);
   };
 
+  add.remove = remove;
+  add.reset = reset;
+  add.flush = flush;
+  add.step = step;
+
   const api: Stub = {
     add,
     remove,
@@ -88,27 +99,22 @@ export default function createStub (frameDuration: number = defaultFrameDuration
 }
 
 type ReplaceRafOptions = {
-    frameDuration?: number,
-    startTime?: number
+  frameDuration?: number,
+  startTime?: number
 };
 
-export function replaceRaf(roots?: Object[] = [], { frameDuration = defaultFrameDuration, startTime = now() }: ReplaceRafOptions = {}) {
+export function replaceRaf(
+  root: ?any,
+  { frameDuration = defaultFrameDuration, startTime = now() }: ReplaceRafOptions = {}
+) {
   // automatic usage of 'window' or 'global' if no roots are provided
-  if (!roots.length) {
-    roots.push(typeof window !== 'undefined' ? window : global);
+  if (root == null) {
+    root = typeof window !== 'undefined' ? window : global
   }
 
   // all roots share the same stub
   const stub = createStub(frameDuration, startTime);
-
-  roots.forEach(root => {
-    root.requestAnimationFrame = stub.add;
-    Object.assign(root.requestAnimationFrame, {
-      step: stub.step,
-      flush: stub.flush,
-      reset: stub.reset,
-    });
-
-    root.cancelAnimationFrame = stub.remove;
-  });
+  root.requestAnimationFrame = stub.add;
+  root.cancelAnimationFrame = stub.remove;
+  return stub.add
 }

--- a/src/index.js
+++ b/src/index.js
@@ -105,16 +105,16 @@ type ReplaceRafOptions = {
 
 export function replaceRaf(
   root: ?any,
-  { frameDuration = defaultFrameDuration, startTime = now() }: ReplaceRafOptions = {}
+  { frameDuration = defaultFrameDuration, startTime = now() }: ReplaceRafOptions = {},
 ) {
   // automatic usage of 'window' or 'global' if no roots are provided
   if (root == null) {
-    root = typeof window !== 'undefined' ? window : global
+    root = typeof window !== 'undefined' ? window : global;
   }
 
   // all roots share the same stub
   const stub = createStub(frameDuration, startTime);
   root.requestAnimationFrame = stub.add;
   root.cancelAnimationFrame = stub.remove;
-  return stub.add
+  return stub.add;
 }

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -400,9 +400,8 @@ describe('replaceRaf', () => {
   it('should return stub', () => {
     const root = {};
     const stub = replaceRaf(root);
-    expect(stub).toBe(root.requestAnimationFrame)
+    expect(stub).toBe(root.requestAnimationFrame);
   });
-
 
   it('should add "step" to the root.requestAnimationFrame', () => {
     const root = {};

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -378,7 +378,7 @@ describe('replaceRaf', () => {
     const root = {};
     const callback = jest.fn();
 
-    replaceRaf([root]);
+    replaceRaf(root);
     root.requestAnimationFrame(callback);
     root.requestAnimationFrame.flush();
 
@@ -389,7 +389,7 @@ describe('replaceRaf', () => {
     const root = {};
     const callback = jest.fn();
 
-    replaceRaf([root]);
+    replaceRaf(root);
     const id = root.requestAnimationFrame(callback);
     root.cancelAnimationFrame(id);
     root.requestAnimationFrame.flush();
@@ -397,11 +397,18 @@ describe('replaceRaf', () => {
     expect(callback).not.toHaveBeenCalled();
   });
 
+  it('should return stub', () => {
+    const root = {};
+    const stub = replaceRaf(root);
+    expect(stub).toBe(root.requestAnimationFrame)
+  });
+
+
   it('should add "step" to the root.requestAnimationFrame', () => {
     const root = {};
     const callback = jest.fn();
 
-    replaceRaf([root]);
+    replaceRaf(root);
     root.requestAnimationFrame(callback);
     root.requestAnimationFrame.step();
 
@@ -412,7 +419,7 @@ describe('replaceRaf', () => {
     const root = {};
     const callback = jest.fn();
 
-    replaceRaf([root]);
+    replaceRaf(root);
     root.requestAnimationFrame(callback);
     root.requestAnimationFrame.flush();
 
@@ -423,8 +430,8 @@ describe('replaceRaf', () => {
     const root = {};
     const callback = jest.fn();
 
-    replaceRaf([root]);
-    replaceRaf([root]);
+    replaceRaf(root);
+    replaceRaf(root);
     root.requestAnimationFrame(callback);
     root.requestAnimationFrame.reset();
     root.requestAnimationFrame.flush();
@@ -432,21 +439,12 @@ describe('replaceRaf', () => {
     expect(callback).not.toHaveBeenCalled();
   });
 
-  it('should share stubs between roots', () => {
-    const root1 = {};
-    const root2 = {};
-
-    replaceRaf([root1, root2]);
-
-    expect(root1.requestAnimationFrame).toBe(root2.requestAnimationFrame);
-  });
-
   it('should not share stubs between different calls', () => {
     const root1 = {};
     const root2 = {};
 
-    replaceRaf([root1]);
-    replaceRaf([root2]);
+    replaceRaf(root1);
+    replaceRaf(root2);
 
     expect(root1.requestAnimationFrame).not.toBe(root2.requestAnimationFrame);
   });
@@ -482,7 +480,7 @@ describe('replaceRaf', () => {
       const root = {};
       const callback = jest.fn();
 
-      replaceRaf([root], { startTime });
+      replaceRaf(root, { startTime });
 
       root.requestAnimationFrame(callback);
       root.requestAnimationFrame.flush();
@@ -495,7 +493,7 @@ describe('replaceRaf', () => {
       const callback = jest.fn();
       const customDuration = defaultFrameDuration * 1000;
 
-      replaceRaf([root], {
+      replaceRaf(root, {
         startTime,
         frameDuration: customDuration,
       });
@@ -511,7 +509,7 @@ describe('replaceRaf', () => {
       const callback = jest.fn();
       const customStartTime = startTime + 1000;
 
-      replaceRaf([root], {
+      replaceRaf(root, {
         startTime: customStartTime,
       });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1770,9 +1770,10 @@ flat-cache@^1.2.1:
     graceful-fs "^4.1.2"
     write "^0.2.1"
 
-flow-bin@0.68.0:
-  version "0.68.0"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.68.0.tgz#86c2d14857d306eb2e85e274f2eebf543564f623"
+flow-bin@0.100.0:
+  version "0.100.0"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.100.0.tgz#729902726658cfa0a81425d6401f9625cf9f5534"
+  integrity sha512-jcethhgrslBJukH7Z7883ohFFpzLrdsOEwHxvn5NwuTWbNaE71GAl55/PEBRJwYpDvYkRlqgcNkANTv0x5XjqA==
 
 flow-copy-source@1.3.0:
   version "1.3.0"


### PR DESCRIPTION
To make stub type-safe we need to return the new type instead of
patching signature of existing global function (it's probably not
possible in flow).

I will submit another PR with build upgrade after merge. Don't release fast please.

Also it's a breaking change.